### PR TITLE
Allow showMouse and setFrozen to be redirected

### DIFF
--- a/rom/apis/term.lua
+++ b/rom/apis/term.lua
@@ -45,6 +45,8 @@ term.redirect = function(target)
     if target.getPixel == nil then target.getPixel = native.getPixel end
     if target.drawPixels == nil then target.drawPixels = native.drawPixels end
     if target.getPixels == nil then target.getPixels = native.getPixels end
+    if target.showMouse == nil then target.showMouse = native.showMouse end
+    if target.setFrozen == nil then target.setFrozen = native.setFrozen end
     for k, v in pairs(native) do
         if type(k) == "string" and type(v) == "function" then
             if type(target[k]) ~= "function" then
@@ -82,7 +84,7 @@ end
 
 -- Some methods shouldn't go through redirects, so we move them to the main
 -- term API.
-for _, method in ipairs { "nativePaletteColor", "nativePaletteColour", "screenshot", "showMouse", "setFrozen" } do
+for _, method in ipairs { "nativePaletteColor", "nativePaletteColour", "screenshot" } do
     term[method] = native[method]
     native[method] = nil
 end

--- a/rom/apis/term.lua
+++ b/rom/apis/term.lua
@@ -40,7 +40,7 @@ term.redirect = function(target)
         error("term is not a recommended redirect target, try term.current() instead", 2)
     end
 
-    for _, method in ipairs({
+    for _, method in ipairs {
         "setGraphicsMode",
         "getGraphicsMode",
         "setPixel",
@@ -49,7 +49,7 @@ term.redirect = function(target)
         "getPixels",
         "showMouse",
         "setFrozen"
-    }) do
+    } do
         if target[method] == nil then
             target[method] = native[method]
         end

--- a/rom/apis/term.lua
+++ b/rom/apis/term.lua
@@ -39,14 +39,22 @@ term.redirect = function(target)
     if target == term or target == _G.term then
         error("term is not a recommended redirect target, try term.current() instead", 2)
     end
-    if target.setGraphicsMode == nil then target.setGraphicsMode = native.setGraphicsMode end
-    if target.getGraphicsMode == nil then target.getGraphicsMode = native.getGraphicsMode end
-    if target.setPixel == nil then target.setPixel = native.setPixel end
-    if target.getPixel == nil then target.getPixel = native.getPixel end
-    if target.drawPixels == nil then target.drawPixels = native.drawPixels end
-    if target.getPixels == nil then target.getPixels = native.getPixels end
-    if target.showMouse == nil then target.showMouse = native.showMouse end
-    if target.setFrozen == nil then target.setFrozen = native.setFrozen end
+
+    for _, method in ipairs({
+        "setGraphicsMode",
+        "getGraphicsMode",
+        "setPixel",
+        "getPixel",
+        "drawPixels",
+        "getPixels",
+        "showMouse",
+        "setFrozen"
+    }) do
+        if target[method] == nil then
+            target[method] = native[method]
+        end
+    end
+
     for k, v in pairs(native) do
         if type(k) == "string" and type(v) == "function" then
             if type(target[k]) ~= "function" then


### PR DESCRIPTION
These should not be unquestionably native functions that deserve to pass through all redirects, because redirects may be interested in them. For example, if you are creating a window-like API that wants to take advantage of `term.setFrozen`, you want to be able to intercept a child coroutine's calls to them when it is redirected to the window. And if you are creating a multishell, well you want to be able to prevent tabs that are not in focus from hiding the mouse randomly.