### PR TITLE
Redirect colour functions to color functions by default

### DIFF
--- a/rom/apis/term.lua
+++ b/rom/apis/term.lua
@@ -64,10 +64,10 @@ term.redirect = function(target)
                     target[k] = function(...)
                         target[delegate](...)
                     end
-                end
-
-                target[k] = function()
-                    error("Redirect object is missing method " .. k .. ".", 2)
+                else
+                    target[k] = function()
+                        error("Redirect object is missing method " .. k .. ".", 2)
+                    end
                 end
             end
         end

--- a/rom/apis/term.lua
+++ b/rom/apis/term.lua
@@ -58,6 +58,14 @@ term.redirect = function(target)
     for k, v in pairs(native) do
         if type(k) == "string" and type(v) == "function" then
             if type(target[k]) ~= "function" then
+                if k:sub(-6, -1) == 'Colour' then
+                    local delegate = target[k:sub(1, -7) .. 'Color']
+
+                    target[k] = function(...)
+                        target[delegate](...)
+                    end
+                end
+
                 target[k] = function()
                     error("Redirect object is missing method " .. k .. ".", 2)
                 end


### PR DESCRIPTION
Alright here is another somewhat controversial proposal. Since the colour variants are just clones of the color variants, I was thinking that they could be redirected by default so you don't have to specify both all the time. Specifying only the color variant in a redirect will cause colour spellings to work correctly right out of the box, rather than `setTextColor` working but `setTextColour` saying `Redirect object is missing method "setTextColour"`.

This will not break existing programs, only improve compatibility.