### PR TITLE
Revert to text mode in shell

### DIFF
--- a/rom/programs/shell.lua
+++ b/rom/programs/shell.lua
@@ -595,6 +595,7 @@ else
     local tCommandHistory = {}
     while not bExit do
         term.redirect(parentTerm)
+        term.setGraphicsMode(0)
         term.setBackgroundColor(bgColour)
         term.setTextColour(promptColour)
         write(shell.dir() .. "> ")


### PR DESCRIPTION
The shell already makes sure that term is redirected correctly every time it shows the prompt, but right now it does not revert from graphics mode. This PR fixes that.